### PR TITLE
Facebook Exclusion

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,6 +3,7 @@
       "all_frames": true,
       "js": ["jquery-1.6.2.min.js", "content.js" ],
       "matches": [ "http://*/*", "https://*/*", "file://*/*" ],
+      "exclude_matches": [ "http://*.facebook.com/*", "https://*.facebook.com/*" ],
       "run_at": "document_start"
    } ],
    "description": "Stop Facebook from tracking you. 2-clicks Like Button.",


### PR DESCRIPTION
I haven't had a chance to test, but this should stop it from running on Facebook its self (where they certainly already track you). It looks ugly in the new ticker stream.
